### PR TITLE
[2026-04-16] C-583: Document S2S player session endpoint v2/identify

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -11,4 +11,5 @@
 * xref:page$other/v2_push_subscription.adoc[Push Subscription Management]
 * xref:page$other/v2_desktop_subscription.adoc[Desktop Web Push Subscription Management]
 * xref:page$other/v2_exclusions.adoc[Exclusion Management]
+* xref:page$other/v2_identify.adoc[Server to Server Player Sessions]
 * xref:page$other/v2_users.adoc[Player Removal]

--- a/modules/ROOT/pages/other/v2_identify.adoc
+++ b/modules/ROOT/pages/other/v2_identify.adoc
@@ -1,0 +1,123 @@
+= Server to Server Player Sessions
+:endpoint: v2/identify
+
+The POST `{endpoint}` endpoint creates or resumes a player session from a server to server context. This is useful for games that manage their own server infrastructure and want to track player sessions, populate player properties for use in audience targeting and message personalization, and resolve deep links with player-specific data.
+
+When a new player is identified for the first time, Teak will create the player record. Subsequent calls for the same player will resume their session.
+
+== Creating or Resuming a Player Session
+[cols="1h,3a", frame="none", grid="none"]
+|===
+| Endpoint
+| https://api.gocarrot.com/{endpoint}
+| Request Type
+| POST
+| Content-Type
+| application/json or application/x-www-form-urlencoded
+|===
+
+=== Required Parameters
+[cols="1,3a", stripes="even"]
+|===
+|Name | Description
+
+| game_id
+| Your Teak App ID
+| secret_key
+| Your Teak Server Secret
+| user_id
+| The Game Assigned Player ID. This must match the value provided by the game client's Teak SDK integration.
+|===
+
+=== Optional Parameters
+[cols="1,3a", stripes="even"]
+|===
+|Name | Description
+
+| timezone
+| The player's timezone as a UTC offset (e.g. `-7.0` for US Pacific Daylight Time). Used for timezone-aware message scheduling.
+| client_ip
+| The player's IP address. Used for GeoIP country resolution. When omitted, the IP address of the requesting server is used, which will not produce meaningful GeoIP data for your players.
+| deep_link
+| A deep link to return in the response. If the link scheme begins with `teak`, xref:ROOT:user-guide:page$custom-tags.adoc[Liquid templating, window=_blank] is applied and xref:ROOT:user-guide:page$player-properties.adoc[Player Property, window=_blank] values can be substituted using `\{{property_name}}` syntax. Non-teak scheme links are returned as-is.
+|===
+
+=== Example Request
+[source, json]
+----
+{
+  "game_id": "your_teak_app_id",
+  "secret_key": "your_server_secret",
+  "user_id": "player_123",
+  "timezone": -7.0,
+  "client_ip": "203.0.113.42",
+  "deep_link": "teak12345:///reward?level={{player_level}}"
+}
+----
+
+=== Success Response
+[cols="1,3a"]
+|===
+| Status Code
+| 201
+| Response Body
+| JSON dictionary.
+[cols="1,3a", stripes="even"]
+!===
+! id
+! Teak's internal numeric ID for the player.
+! game_id
+! The numeric ID of the game.
+! country_code
+! Two-letter ISO country code derived from GeoIP lookup of `client_ip` (or the request IP if `client_ip` is not provided). Empty string if GeoIP lookup fails.
+! opt_out_states
+! A dictionary of channel opt-out states for this player. Contains keys `email`, `push`, and `sms`, each with a `state` value indicating the player's current opt-out preference for that channel.
+! user_profile
+! The player's current xref:ROOT:user-guide:page$player-properties.adoc[Player Properties, window=_blank]. A dictionary containing: +
+'string_attributes' is a map of string property names to their current values. +
+'number_attributes' is a map of number property names to their current values. +
+'context' is an opaque string for internal use.
+! deep_link
+! _(Only present if `deep_link` was provided in the request.)_ The deep link after Liquid template rendering. Player Property values are substituted for `\{{property_name}}` placeholders in links with a `teak` scheme. Non-teak scheme links are returned unmodified.
+!===
+| Example
+| [source, json]
+----
+{
+  "id": 12345,
+  "game_id": 678,
+  "country_code": "US",
+  "opt_out_states": {
+    "email": {"state": "opted_in"},
+    "push": {"state": "opted_in"},
+    "sms": {"state": "opted_out_no_data"}
+  },
+  "user_profile": {
+    "string_attributes": {
+      "player_level": "elite"
+    },
+    "number_attributes": {
+      "high_score": 9001.0
+    },
+    "context": "..."
+  },
+  "deep_link": "teak12345:///reward?level=elite"
+}
+----
+|===
+
+=== Error Responses
+
+==== Forbidden
+
+:response-code: 403
+:response-body: JSON dictionary with 'status' and 'errors' keys. 'status' will be 'error'. 'errors' will be a dictionary containing keys indicating which parameters were invalid, with values being an array of human readable error messages.
+:response-example: {"status":"error","errors":{"authorization":["is invalid"]}}
+include::partial$response.adoc[]
+
+==== Not Found
+
+:response-code: 404
+:response-body: JSON dictionary with an 'error' key containing a dictionary with 'code' and 'message' keys.
+:response-example: {"error":{"code":404,"message":"Could not find game with id unknown_app_id"}}
+include::partial$response.adoc[]

--- a/modules/ROOT/pages/other/v2_identify.adoc
+++ b/modules/ROOT/pages/other/v2_identify.adoc
@@ -64,19 +64,10 @@ When a new player is identified for the first time, Teak will create the player 
 | JSON dictionary.
 [cols="1,3a", stripes="even"]
 !===
-! id
-! Teak's internal numeric ID for the player.
-! game_id
-! The numeric ID of the game.
 ! country_code
 ! Two-letter ISO country code derived from GeoIP lookup of `client_ip` (or the request IP if `client_ip` is not provided). Empty string if GeoIP lookup fails.
 ! opt_out_states
 ! A dictionary of channel opt-out states for this player. Contains keys `email`, `push`, and `sms`, each with a `state` value indicating the player's current opt-out preference for that channel.
-! user_profile
-! The player's current xref:ROOT:user-guide:page$player-properties.adoc[Player Properties, window=_blank]. A dictionary containing: +
-'string_attributes' is a map of string property names to their current values. +
-'number_attributes' is a map of number property names to their current values. +
-'context' is an opaque string for internal use.
 ! deep_link
 ! _(Only present if `deep_link` was provided in the request.)_ The deep link after Liquid template rendering. Player Property values are substituted for `\{{property_name}}` placeholders in links with a `teak` scheme. Non-teak scheme links are returned unmodified.
 !===
@@ -84,22 +75,11 @@ When a new player is identified for the first time, Teak will create the player 
 | [source, json]
 ----
 {
-  "id": 12345,
-  "game_id": 678,
   "country_code": "US",
   "opt_out_states": {
     "email": {"state": "opted_in"},
     "push": {"state": "opted_in"},
     "sms": {"state": "opted_out_no_data"}
-  },
-  "user_profile": {
-    "string_attributes": {
-      "player_level": "elite"
-    },
-    "number_attributes": {
-      "high_score": 9001.0
-    },
-    "context": "..."
   },
   "deep_link": "teak12345:///reward?level=elite"
 }

--- a/modules/ROOT/pages/other/v2_identify.adoc
+++ b/modules/ROOT/pages/other/v2_identify.adoc
@@ -2,13 +2,13 @@
 :endpoint: v2/identify
 :rate_limit: 200
 
-The POST `{endpoint}` endpoint creates or resumes a player session from a server to server context. This is useful for games that manage their own server infrastructure and want to track player sessions, populate player properties for use in audience targeting and message personalization, and resolve deep links with player-specific data.
+The POST `{endpoint}` endpoint records that a player has started a session and returns data about the player. This is useful for games that cannot integrate the Teak SDK.
 
-When a new player is identified for the first time, Teak will create the player record. Subsequent calls for the same player will resume their session.
+Each call to this endpoint tracks a new session. This drives the xref:ROOT:user-guide:page$audiences.adoc#_played[Played, window=_blank] event in the Audience builder. If Teak has not seen this player before, it also tracks an xref:ROOT:user-guide:page$audiences.adoc#_installed[Installed, window=_blank] event.
 
-NOTE: If a player has been permanently opted out via data removal, the session will still be created but no push tokens, email addresses, or advertising identifiers will be stored or updated for the player.
+NOTE: If a player has been permanently opted out via xref:page$other/v2_exclusions.adoc[exclusion], the session will still be tracked but no push tokens, email addresses, or advertising identifiers will be stored or updated for the player.
 
-== Creating or Resuming a Player Session
+== Recording a Player Session
 [cols="1h,3a", frame="none", grid="none"]
 |===
 | Endpoint
@@ -46,7 +46,7 @@ NOTE: If a player has been permanently opted out via data removal, the session w
 | email
 | An email address for this player. When provided, Teak will store or update the player's email address for use in email marketing campaigns. If the player has been permanently opted out, the email address will not be stored.
 | deep_link
-| A deep link to return in the response. If the link scheme begins with `teak`, xref:ROOT:user-guide:page$custom-tags.adoc[Liquid templating, window=_blank] is applied and xref:ROOT:user-guide:page$player-properties.adoc[Player Properties, window=_blank] values can be substituted using `\{{property_name}}` syntax. Non-teak scheme links are returned as-is.
+| A deep link to return in the response. If the link is a Teak managed link — either a `teak` custom scheme URL or a URL matching a Teak link domain — it is resolved to a custom scheme deep link with xref:ROOT:user-guide:page$custom-tags.adoc[Liquid templating, window=_blank] applied. xref:ROOT:user-guide:page$player-properties.adoc[Player Properties, window=_blank] values can be substituted using `\{{property_name}}` syntax. Other links are returned as-is.
 |===
 
 === Example Request
@@ -75,11 +75,11 @@ NOTE: If a player has been permanently opted out via data removal, the session w
 ! country_code
 ! Two-letter ISO country code derived from GeoIP lookup of `client_ip` (or the request IP if `client_ip` is not provided). Empty string if GeoIP lookup fails.
 ! session_id
-! An identifier for this player session. Present when a session is successfully created.
+! An identifier for this player session. Present when a session is successfully tracked.
 ! opt_out_states
 ! A dictionary of channel opt-out states for this player. Contains keys `email`, `push`, and `sms`, each with a `state` value indicating the player's current opt-out preference for that channel.
 ! deep_link
-! _(Only present if `deep_link` was provided in the request.)_ The deep link after Liquid template rendering. Player Property values are substituted for `\{{property_name}}` placeholders in links with a `teak` scheme. Non-teak scheme links are returned unmodified.
+! _(Only present if `deep_link` was provided in the request.)_ The processed deep link. Teak managed links — `teak` custom scheme URLs and Teak link domain URLs — are resolved to a custom scheme deep link with Liquid templating applied. xref:ROOT:user-guide:page$player-properties.adoc[Player Properties, window=_blank] values are substituted for `\{{property_name}}` placeholders. Other links are returned unmodified.
 !===
 | Example
 | [source, json]

--- a/modules/ROOT/pages/other/v2_identify.adoc
+++ b/modules/ROOT/pages/other/v2_identify.adoc
@@ -99,6 +99,13 @@ NOTE: If a player has been permanently opted out via data removal, the session w
 
 === Error Responses
 
+==== Bad Request
+
+:response-code: 400
+:response-body: JSON dictionary with 'status' and 'errors' keys. 'status' will be 'error'. 'errors' will be a dictionary containing keys for each invalid parameter, with values being an array of human readable error messages. All validation errors are returned at once.
+:response-example: {"status":"error","errors":{"timezone_id":["Mars/Olympus_Mons is not a recognized IANA timezone name"],"client_ip":["not-an-ip is not a valid IP address"]}}
+include::partial$response.adoc[]
+
 ==== Forbidden
 
 :response-code: 403

--- a/modules/ROOT/pages/other/v2_identify.adoc
+++ b/modules/ROOT/pages/other/v2_identify.adoc
@@ -39,8 +39,8 @@ NOTE: If a player has been permanently opted out via data removal, the session w
 |===
 |Name | Description
 
-| timezone
-| The player's timezone as a UTC offset (e.g. `-7.0` for US Pacific Daylight Time). Used for timezone-aware message scheduling.
+| timezone_id
+| The player's IANA timezone name (e.g. `America/Los_Angeles`). Used for timezone-aware message scheduling. When omitted, UTC is assumed.
 | client_ip
 | The player's IP address. Used for GeoIP country resolution. When omitted, the IP address of the requesting server is used, which will not produce meaningful GeoIP data for your players.
 | email
@@ -56,7 +56,7 @@ NOTE: If a player has been permanently opted out via data removal, the session w
   "game_id": "your_teak_app_id",
   "secret_key": "your_server_secret",
   "user_id": "player_123",
-  "timezone": -7.0,
+  "timezone_id": "America/Los_Angeles",
   "client_ip": "203.0.113.42",
   "email": "player@example.com",
   "deep_link": "teak12345:///reward?level={{player_level}}"

--- a/modules/ROOT/pages/other/v2_identify.adoc
+++ b/modules/ROOT/pages/other/v2_identify.adoc
@@ -42,7 +42,9 @@ NOTE: If a player has been permanently opted out via xref:page$other/v2_exclusio
 | timezone_id
 | The player's IANA timezone name (e.g. `America/Los_Angeles`). Used for timezone-aware message scheduling. When omitted, UTC is assumed.
 | client_ip
-| The player's IP address. Used for GeoIP country resolution. When omitted, the IP address of the requesting server is used, which will not produce meaningful GeoIP data for your players.
+| The player's IP address. Used for GeoIP country resolution. Either `client_ip` or `country_code` must be provided. If both are provided, `client_ip` takes priority. If neither the player's IP address nor country are known, pass `127.0.0.1`.
+| country_code
+| Two-letter ISO country code (e.g. `US`, `DE`). Used when the player's IP address is not available but their country is known. Either `client_ip` or `country_code` must be provided. If both are provided, `client_ip` takes priority.
 | email
 | An email address for this player. When provided, Teak will store or update the player's email address for use in email marketing campaigns. If the player has been permanently opted out, the email address will not be stored.
 | deep_link
@@ -73,7 +75,7 @@ NOTE: If a player has been permanently opted out via xref:page$other/v2_exclusio
 [cols="1,3a", stripes="even"]
 !===
 ! country_code
-! Two-letter ISO country code derived from GeoIP lookup of `client_ip` (or the request IP if `client_ip` is not provided). Empty string if GeoIP lookup fails.
+! Two-letter ISO country code. When `client_ip` is provided, this is derived from GeoIP lookup. When `country_code` is provided instead, this echoes the provided value. Empty string if GeoIP lookup fails.
 ! session_id
 ! An identifier for this player session. Present when a session is successfully tracked.
 ! opt_out_states
@@ -103,7 +105,7 @@ NOTE: If a player has been permanently opted out via xref:page$other/v2_exclusio
 
 :response-code: 400
 :response-body: JSON dictionary with 'status' and 'errors' keys. 'status' will be 'error'. 'errors' will be a dictionary containing keys for each invalid parameter, with values being an array of human readable error messages. All validation errors are returned at once.
-:response-example: {"status":"error","errors":{"timezone_id":["Mars/Olympus_Mons is not a recognized IANA timezone name"],"client_ip":["not-an-ip is not a valid IP address"]}}
+:response-example: {"status":"error","errors":{"timezone_id":["Mars/Olympus_Mons is not a recognized IANA timezone name"],"location":["either client_ip or country_code must be provided"]}}
 include::partial$response.adoc[]
 
 ==== Forbidden

--- a/modules/ROOT/pages/other/v2_identify.adoc
+++ b/modules/ROOT/pages/other/v2_identify.adoc
@@ -46,7 +46,7 @@ NOTE: If a player has been permanently opted out via data removal, the session w
 | email
 | An email address for this player. When provided, Teak will store or update the player's email address for use in email marketing campaigns. If the player has been permanently opted out, the email address will not be stored.
 | deep_link
-| A deep link to return in the response. If the link scheme begins with `teak`, xref:ROOT:user-guide:page$custom-tags.adoc[Liquid templating, window=_blank] is applied and xref:ROOT:user-guide:page$player-properties.adoc[Player Property, window=_blank] values can be substituted using `\{{property_name}}` syntax. Non-teak scheme links are returned as-is.
+| A deep link to return in the response. If the link scheme begins with `teak`, xref:ROOT:user-guide:page$custom-tags.adoc[Liquid templating, window=_blank] is applied and xref:ROOT:user-guide:page$player-properties.adoc[Player Properties, window=_blank] values can be substituted using `\{{property_name}}` syntax. Non-teak scheme links are returned as-is.
 |===
 
 === Example Request

--- a/modules/ROOT/pages/other/v2_identify.adoc
+++ b/modules/ROOT/pages/other/v2_identify.adoc
@@ -88,9 +88,9 @@ NOTE: If a player has been permanently opted out via data removal, the session w
   "country_code": "US",
   "session_id": "12345",
   "opt_out_states": {
-    "email": {"state": "opted_in"},
-    "push": {"state": "opted_in"},
-    "sms": {"state": "opted_out_no_data"}
+    "email": {"state": "opt_in"},
+    "push": {"state": "opt_in"},
+    "sms": {"state": "opt_out"}
   },
   "deep_link": "teak12345:///reward?level=elite"
 }

--- a/modules/ROOT/pages/other/v2_identify.adoc
+++ b/modules/ROOT/pages/other/v2_identify.adoc
@@ -43,6 +43,8 @@ NOTE: If a player has been permanently opted out via data removal, the session w
 | The player's timezone as a UTC offset (e.g. `-7.0` for US Pacific Daylight Time). Used for timezone-aware message scheduling.
 | client_ip
 | The player's IP address. Used for GeoIP country resolution. When omitted, the IP address of the requesting server is used, which will not produce meaningful GeoIP data for your players.
+| email
+| An email address for this player. When provided, Teak will store or update the player's email address for use in email marketing campaigns. If the player has been permanently opted out, the email address will not be stored.
 | deep_link
 | A deep link to return in the response. If the link scheme begins with `teak`, xref:ROOT:user-guide:page$custom-tags.adoc[Liquid templating, window=_blank] is applied and xref:ROOT:user-guide:page$player-properties.adoc[Player Property, window=_blank] values can be substituted using `\{{property_name}}` syntax. Non-teak scheme links are returned as-is.
 |===
@@ -56,6 +58,7 @@ NOTE: If a player has been permanently opted out via data removal, the session w
   "user_id": "player_123",
   "timezone": -7.0,
   "client_ip": "203.0.113.42",
+  "email": "player@example.com",
   "deep_link": "teak12345:///reward?level={{player_level}}"
 }
 ----

--- a/modules/ROOT/pages/other/v2_identify.adoc
+++ b/modules/ROOT/pages/other/v2_identify.adoc
@@ -1,9 +1,12 @@
 = Server to Server Player Sessions
 :endpoint: v2/identify
+:rate_limit: 200
 
 The POST `{endpoint}` endpoint creates or resumes a player session from a server to server context. This is useful for games that manage their own server infrastructure and want to track player sessions, populate player properties for use in audience targeting and message personalization, and resolve deep links with player-specific data.
 
 When a new player is identified for the first time, Teak will create the player record. Subsequent calls for the same player will resume their session.
+
+NOTE: If a player has been permanently opted out via data removal, the session will still be created but no push tokens, email addresses, or advertising identifiers will be stored or updated for the player.
 
 == Creating or Resuming a Player Session
 [cols="1h,3a", frame="none", grid="none"]
@@ -14,6 +17,8 @@ When a new player is identified for the first time, Teak will create the player 
 | POST
 | Content-Type
 | application/json or application/x-www-form-urlencoded
+| Rate Limiting
+| {rate_limit} requests per second
 |===
 
 === Required Parameters
@@ -66,6 +71,8 @@ When a new player is identified for the first time, Teak will create the player 
 !===
 ! country_code
 ! Two-letter ISO country code derived from GeoIP lookup of `client_ip` (or the request IP if `client_ip` is not provided). Empty string if GeoIP lookup fails.
+! session_id
+! An identifier for this player session. Present when a session is successfully created.
 ! opt_out_states
 ! A dictionary of channel opt-out states for this player. Contains keys `email`, `push`, and `sms`, each with a `state` value indicating the player's current opt-out preference for that channel.
 ! deep_link
@@ -76,6 +83,7 @@ When a new player is identified for the first time, Teak will create the player 
 ----
 {
   "country_code": "US",
+  "session_id": "12345",
   "opt_out_states": {
     "email": {"state": "opted_in"},
     "push": {"state": "opted_in"},
@@ -100,4 +108,11 @@ include::partial$response.adoc[]
 :response-code: 404
 :response-body: JSON dictionary with an 'error' key containing a dictionary with 'code' and 'message' keys.
 :response-example: {"error":{"code":404,"message":"Could not find game with id unknown_app_id"}}
+include::partial$response.adoc[]
+
+==== Rate Limit Response
+
+:response-code: 429
+:response-body: JSON dictionary with 'status' and 'errors' keys. 'status' will be 'rate_limit'. 'errors' will contain the key 'rate_limit'
+:response-example: {"status":"rate_limit","errors":{"rate_limit":["/{endpoint} may only be called {rate_limit} times per second. Please wait a second and try again"]}}
 include::partial$response.adoc[]


### PR DESCRIPTION
Add API documentation for the server-to-server identify endpoint covering request payload (game_id, secret_key, user_id, timezone, client_ip, deep_link), success response (201 with player data, opt-out states, player properties, templated deep links), and error responses (403, 404).

## Human-Claude Interaction Log

### Human prompts (VERBATIM):
1. "Take a look at ../server-api-docs and sketch out the request payload and response payload for this new API call form." → Claude: Explored the server-api-docs repo structure (Antora/AsciiDoc), read existing endpoint docs for conventions, then sketched out request and response payloads in markdown for review.

2. "Go ahead and update the docs." → Claude: Created modules/ROOT/pages/other/v2_identify.adoc following the existing AsciiDoc conventions (metadata table, parameter tables, nested response field tables, error response partials). Added nav entry.

3. "Commit your work." → Claude: Committed the documentation changes.

### Key decisions made:
- Human guided: write the docs in server-api-docs repo following existing conventions
- Claude discovered: existing docs use AsciiDoc/Antora with specific table formatting, response partials, and xref cross-references; 404 error format differs from other endpoints (uses {error:{code,message}} not {status,errors})

🤖 Generated with Claude Code