### PR TITLE
Document bulk live activity S2S endpoints (C-905)

### DIFF
--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -20,11 +20,11 @@ Here are the common server-side features you should consider implementing:
 * xref:server-api::page$notifications/v2_schedule.adoc[*API Driven Notification Sends*] +
 Programmatically schedule notifications for players at specific times or in response to in-game events.
 
-* xref:server-api::page$notifications/v2_scheduled_notifications.adoc[*Bulk Schedule Creation*] +
-Create scheduled notifications in bulk that can be edited and managed in the Teak Dashboard.
-
 * xref:server-api::page$notifications/v2_schedule_live_activity_updates.adoc[*Bulk Live Activity Updates*] +
 Schedule and cancel iOS Live Activity updates for a batch of players from your backend.
+
+* xref:server-api::page$notifications/v2_scheduled_notifications.adoc[*Bulk Schedule Creation*] +
+Create scheduled notifications in bulk that can be edited and managed in the Teak Dashboard.
 
 === Rewards & Player Data
 

--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -23,6 +23,9 @@ Programmatically schedule notifications for players at specific times or in resp
 * xref:server-api::page$notifications/v2_scheduled_notifications.adoc[*Bulk Schedule Creation*] +
 Create scheduled notifications in bulk that can be edited and managed in the Teak Dashboard.
 
+* xref:server-api::page$notifications/v2_schedule_live_activity_updates.adoc[*Bulk Live Activity Updates*] +
+Schedule and cancel iOS Live Activity updates for a batch of players from your backend.
+
 === Rewards & Player Data
 
 * xref:server-api::page$rewards/endpoint.adoc[*Teak Reward Endpoint*] +

--- a/modules/ROOT/pages/notifications/v2_schedule_live_activity_updates.adoc
+++ b/modules/ROOT/pages/notifications/v2_schedule_live_activity_updates.adoc
@@ -55,7 +55,7 @@ Per-player failures do not fail the batch. Any player that cannot be scheduled i
 
 WARNING: `custom_data` is structurally optional — omitting it will not fail request validation — but it is effectively required per-player. A player with no entry in the `custom_data` map lands in `errors.user_ids` and is *not* scheduled. To schedule an update for a player, include that player in `custom_data`.
 
-NOTE: `send_time` is validated twice, with different blast radius. A `send_time` more than 30 days in the future (or one that cannot be parsed) is a hard validation error that rejects the *entire* request with a `422`. Separately, each individual update must fall within 10 hours of when that player's Live Activity was created; a player whose `send_time` is outside that horizon is reported per-player in `errors.user_ids` while the rest of the batch is scheduled.
+NOTE: `send_time` is validated twice, with different blast radius. A `send_time` more than 30 days in the future (or one that cannot be parsed) is a hard validation error that rejects the *entire* request with a `422`. Separately, each individual update must fall within 10 hours of when that player's Live Activity was created; a player whose `send_time` is outside that horizon is reported per-player in `errors.user_ids` while the rest of the batch is scheduled. Note that an omitted `send_time` defaults to the current time, so the horizon applies to immediate updates as well: a player whose Live Activity was created more than 10 hours ago is reported in `errors.user_ids` rather than delivered immediately.
 
 === Success Response
 :response-code: 200

--- a/modules/ROOT/pages/notifications/v2_schedule_live_activity_updates.adoc
+++ b/modules/ROOT/pages/notifications/v2_schedule_live_activity_updates.adoc
@@ -44,7 +44,7 @@ Per-player failures do not fail the batch. Any player that cannot be scheduled i
 |Name | Description
 
 | send_time
-| The time in UTC at which to deliver the update. Must be in ISO8601 format, e.g. "2018-08-23 17:00:00". Must be within 30 days from the time the call is made. If omitted, or if set to a past time, the update will be scheduled to deliver immediately. See the horizon note below.
+| The time in UTC at which to deliver the update. Must be in ISO8601 format, e.g. "2018-08-23 17:00:00". Must be within 30 days from the time the call is made. If omitted it defaults to the current time; a past time (or the default) delivers as soon as possible, subject to the 10-hour horizon in the note below.
 | custom_data
 | A map of Game Assigned Player IDs to the update payload for that player. Each value may be either a JSON object or a pre-serialized JSON string. See the warning below.
 | system_data

--- a/modules/ROOT/pages/notifications/v2_schedule_live_activity_updates.adoc
+++ b/modules/ROOT/pages/notifications/v2_schedule_live_activity_updates.adoc
@@ -1,0 +1,179 @@
+= Bulk Live Activity Updates
+
+These server-to-server endpoints schedule and cancel https://developer.apple.com/documentation/activitykit[Live Activity, window=_blank] updates for a batch of players at once. They mirror the shape of the xref:server-api::page$notifications/v2_schedule.adoc[bulk notification scheduling] endpoints: a shared `live_activity_id` and `send_time` across a `user_ids` batch, with per-user `custom_data`, `system_data`, and `device_ids` maps.
+
+Before an update can be scheduled for a player, that player's device must have started a Live Activity and registered its push token with Teak under the matching `live_activity_id`. Players with no matching Live Activity are reported per-user in the response rather than failing the whole call.
+
+== Scheduling
+[cols="1h,3a", frame="none", grid="none"]
+|===
+| Endpoint
+| https://api.gocarrot.com/v2/schedule_live_activity_updates
+| Request Type
+| POST
+| Content-Type
+| application/json or application/x-www-form-urlencoded
+| Rate Limiting
+| 30 requests per second
+|===
+
+Description: The `v2/schedule_live_activity_updates` endpoint schedules a Live Activity update for each player in `user_ids`. Every player in the batch shares the same `live_activity_id` and `send_time`, while `custom_data`, `system_data`, and `device_ids` are keyed per-player.
+
+Per-player failures do not fail the batch. Any player that cannot be scheduled is reported under the `errors.user_ids` map in an otherwise-successful `200` response, and the remaining players are scheduled normally.
+
+=== Required Parameters
+
+[cols="1,3a", stripes="even"]
+|===
+|Name | Description
+
+| game_id
+| Your Teak App ID
+| secret_key
+| Your Teak Server Secret
+| live_activity_id
+| The identifier of the Live Activity to update. Must match the `live_activity_id` the player's device registered when it started the Live Activity.
+| user_ids
+| Array of Game Assigned Player IDs to schedule the update for. Maximum of 100 per call. If you need to schedule the update for more users, make additional calls.
+|===
+
+=== Optional Parameters
+
+[cols="1,3a", stripes="even"]
+|===
+|Name | Description
+
+| send_time
+| The time in UTC at which to deliver the update. Must be in ISO8601 format, e.g. "2018-08-23 17:00:00". Must be within 30 days from the time the call is made. If omitted, or if set to a past time, the update will be scheduled to deliver immediately. See the horizon note below.
+| custom_data
+| A map of Game Assigned Player IDs to the update payload for that player. Each value may be either a JSON object or a pre-serialized JSON string. See the warning below.
+| system_data
+| A map of Game Assigned Player IDs to a system payload for that player, in the same shape as `custom_data` (JSON object or pre-serialized JSON string). Players may be omitted.
+| device_ids
+| A map of Game Assigned Player IDs to Teak Device IDs. When provided, the update is targeted to the specified device for that player instead of their most recently registered Live Activity device. Players included in `user_ids` but not in `device_ids` target their most recent Live Activity. If a device ID cannot be resolved (e.g. the device does not exist, does not belong to the player, or has no matching Live Activity), that player is skipped and reported in `errors.user_ids`.
+|===
+
+WARNING: `custom_data` is structurally optional — omitting it will not fail request validation — but it is effectively required per-player. A player with no entry in the `custom_data` map lands in `errors.user_ids` and is *not* scheduled. To schedule an update for a player, include that player in `custom_data`.
+
+NOTE: `send_time` is validated twice, with different blast radius. A `send_time` more than 30 days in the future (or one that cannot be parsed) is a hard validation error that rejects the *entire* request with a `422`. Separately, each individual update must fall within 10 hours of when that player's Live Activity was created; a player whose `send_time` is outside that horizon is reported per-player in `errors.user_ids` while the rest of the batch is scheduled.
+
+=== Success Response
+:response-code: 200
+:response-body: JSON dictionary with 'status', 'ids', and 'scheduled' keys. 'status' will be 'ok'. 'ids' will contain an array of strings which are opaque ids for the updates scheduled. Every update will have a unique id. 'scheduled' will be a map of Game Assigned Player ID to the opaque update id for that player. If any player could not be scheduled, an 'errors' key will be present containing a 'user_ids' map of the Game Assigned Player ID to a human readable error message. Players in the 'errors.user_ids' map will not have updates scheduled.
+:response-example: {"status":"ok", "ids":["12904919075210912"], "scheduled":{"player_1":"12904919075210912"}}
+include::partial$response.adoc[]
+
+==== Partial Per-Player Failure
+
+When one or more players cannot be scheduled, the response still returns a `200` status. Successfully scheduled players appear in `scheduled`. Failed players are reported in the `errors.user_ids` map with a human readable reason (e.g. no matching Live Activity, unknown player id, missing `custom_data`, a `send_time` outside the 10-hour horizon, or an unresolvable device id).
+
+[source,json]
+----
+{
+  "status": "ok",
+  "ids": ["12904919075210912"],
+  "scheduled": {
+    "player_1": "12904919075210912"
+  },
+  "errors": {
+    "user_ids": {
+      "player_2": "no matching live activity"
+    }
+  }
+}
+----
+
+=== Error Responses
+
+==== Not Found
+
+:response-code: 404
+:response-body: JSON dictionary with 'status' and 'errors' keys. 'status' will be 'error'. 'errors' will be a dictionary in which the keys are the parameter which could not be found, and the values will be an array of human readable messages indicating what could not be found.
+:response-example: {"status":"error","errors":{"game_id":["Unknown app id 42"]}}
+include::partial$response.adoc[]
+
+==== Validation Error
+
+:response-code: 422
+:response-body: JSON dictionary with 'status' and 'errors' keys. 'status' will be 'error'. 'errors' will be a dictionary in which the keys are the parameter which failed to meet requirements, and the values will be an array of human readable messages for failed validations. A validation error rejects the entire request; no updates are scheduled.
+:response-example: {"status":"error","errors":{"live_activity_id":["must be present"]}}
+include::partial$response.adoc[]
+
+==== Rate Limit Response
+
+:response-code: 429
+:response-body: JSON dictionary with 'status' and 'errors' keys. 'status' will be 'rate_limit'. 'errors' will contain the key 'rate_limit'
+:response-example: {"status":"rate_limit","errors":{"rate_limit":["/v2/schedule_live_activity_updates may only be called 30 times per second. Please wait a second and try again"]}}
+include::partial$response.adoc[]
+
+== Cancelling/Unscheduling
+[cols="1h,3a", frame="none", grid="none"]
+|===
+| Endpoint
+| https://api.gocarrot.com/v2/unschedule_live_activity_updates
+| Request Type
+| POST
+| Content-Type
+| application/json or application/x-www-form-urlencoded
+| Rate Limiting
+| 30 requests per second
+|===
+
+Description: The `v2/unschedule_live_activity_updates` endpoint cancels pending Live Activity updates scheduled with `v2/schedule_live_activity_updates`. Cancellation is scoped to a single `live_activity_id` across the players in `user_ids`.
+
+NOTE: Unlike xref:server-api::page$notifications/v2_schedule.adoc#_cancelling_unscheduling[notification unscheduling], this endpoint does not accept an `ids` array and has no `notification_identifier`. Updates to cancel are identified solely by `live_activity_id` and `user_ids` (optionally narrowed by `device_ids`). For a player without a `device_ids` entry, *all* of that player's pending updates for the given `live_activity_id` are cancelled.
+
+=== Required Parameters
+
+[cols="1,3a", stripes="even"]
+|===
+|Name | Description
+
+| game_id
+| Your Teak App ID
+| secret_key
+| Your Teak Server Secret
+| live_activity_id
+| The identifier of the Live Activity whose updates should be cancelled.
+| user_ids
+| Array of Game Assigned Player IDs to cancel updates for. Maximum of 100 per call. If you need to cancel updates for more users, make additional calls.
+|===
+
+=== Optional Parameters
+
+[cols="1,3a", stripes="even"]
+|===
+|Name | Description
+
+| device_ids
+| A map of Game Assigned Player IDs to Teak Device IDs. When provided, only the pending updates for the specified device are cancelled for that player. Players included in `user_ids` but not in `device_ids` have all of their pending updates for this `live_activity_id` cancelled. If a device ID cannot be resolved, that player is skipped and reported in `errors.user_ids`.
+|===
+
+=== Success Response
+:response-code: 200
+:response-body: JSON dictionary with 'status' and 'ids' keys. 'status' will be 'ok'. 'ids' will contain an array of strings which are the opaque ids of the updates that were cancelled; it will be empty if no matching updates were found. If a supplied device id could not be resolved, an 'errors' key will be present containing a 'user_ids' map of the Game Assigned Player ID to a human readable error message.
+:response-example: {"status":"ok", "ids":["12904919075210912"]}
+include::partial$response.adoc[]
+
+=== Error Responses
+
+==== Not Found
+
+:response-code: 404
+:response-body: JSON dictionary with 'status' and 'errors' keys. 'status' will be 'error'. 'errors' will be a dictionary in which the keys are the parameter which could not be found, and the values will be an array of human readable messages indicating what could not be found.
+:response-example: {"status":"error","errors":{"game_id":["Unknown app id 42"]}}
+include::partial$response.adoc[]
+
+==== Validation Error
+
+:response-code: 422
+:response-body: JSON dictionary with 'status' and 'errors' keys. 'status' will be 'error'. 'errors' will be a dictionary in which the keys are the parameter which failed to meet requirements, and the values will be an array of human readable messages for failed validations.
+:response-example: {"status":"error","errors":{"live_activity_id":["must be present"]}}
+include::partial$response.adoc[]
+
+==== Rate Limit Response
+
+:response-code: 429
+:response-body: JSON dictionary with 'status' and 'errors' keys. 'status' will be 'rate_limit'. 'errors' will contain the key 'rate_limit'
+:response-example: {"status":"rate_limit","errors":{"rate_limit":["/v2/unschedule_live_activity_updates may only be called 30 times per second. Please wait a second and try again"]}}
+include::partial$response.adoc[]

--- a/modules/ROOT/partials/nav-server-api.adoc
+++ b/modules/ROOT/partials/nav-server-api.adoc
@@ -1,5 +1,6 @@
 ** xref:server-api::page$index.adoc[Server API]
 *** xref:server-api::page$notifications/v2_schedule.adoc[API Driven Notification Sends]
+*** xref:server-api::page$notifications/v2_schedule_live_activity_updates.adoc[Bulk Live Activity Updates]
 *** xref:server-api::page$notifications/v2_scheduled_notifications.adoc[Bulk Schedule Creation]
 *** xref:server-api::page$notifications/v2_messages.adoc[Messages Management]
 *** xref:server-api::page$other/v2_player_properties.adoc[Player Properties]


### PR DESCRIPTION
Closes #c-905

Documents the two bulk Live Activity S2S endpoints shipped in carrot C-620, which were flagged as needing docs in that review. New page `notifications/v2_schedule_live_activity_updates.adoc` (+ nav and index entries), mirroring the `v2/schedule` bulk-notification doc structure.

### Shape provenance (for spot-checking against carrot)

Every documented shape is read from the C-620 implementation, not assumed from the notification endpoint:

- **Endpoints + routes**: carrot #1979 `config/routes.rb` → `bulk_live_activity_update#schedule` / `#unschedule`
- **Request params, per-user error surface, validations**: carrot #1979 `app/controllers/bulk_live_activity_update_controller.rb`
- **`scheduled` / `ids` / `errors.user_ids` response body + custom_data/system_data/device_ids semantics**: carrot #1978 `app/services/business_process/schedule_bulk_live_activity_update.rb`
- **10-hour horizon + per-user error strings** ("no matching live activity", custom_data required): carrot `app/services/business_process/schedule_live_activity_update.rb` (develop)

Constants read from code (not carried over):
- `MAX_USER_IDS = 100` — controller
- `send_time < 30.days.from_now` — controller `extract_send_time`
- `MAX_SEND_HORIZON = 10.hours` — `ScheduleLiveActivityUpdate`
- `DEFAULT_REQUEST_PER_SECOND_LIMIT = 30` — controller

### Three nuances called out in the docs

1. **`custom_data` warning** — structurally optional (won't 422) but a player with no entry lands in `errors.user_ids` and is silently not scheduled. Documented as a WARNING admonition.
2. **`send_time` two gates, different blast radius** — >30d (or unparseable) is a hard 422 rejecting the whole request; the 10h-from-creation horizon is a per-user error that still processes the rest.
3. **Non-parity with `v2/unschedule`** — no `ids`-based cancel, no `notification_identifier`; cancellation is scoped purely by `live_activity_id` + `user_ids` (+ optional `device_ids`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
